### PR TITLE
stop messing up args after the user command

### DIFF
--- a/src/slurm2flux.pl
+++ b/src/slurm2flux.pl
@@ -530,17 +530,21 @@ sub GetOpts
     my @tmpargv;
     my $prevarg = my $doubledash = '';
     foreach my $tmp (@ARGV){
-        if( $tmp =~ /^(\-\w)(\S+)/ and 
-                push(@tmpargv, $1),
-                push(@tmpargv, $2) ){
-            $prevarg = $2;
-        }else{
-            if( !$doubledash and $tmp !~ /^\-/ and ($prevarg !~ /^\-/i or is_singlearg($prevarg)) ){
-                push @tmpargv, '--';
-                $doubledash = 'yes';
+        if( !$doubledash ){
+            if( $tmp =~ /^(\-\w)(\S+)/ and 
+                    push(@tmpargv, $1),
+                    push(@tmpargv, $2) ){
+                $prevarg = $2;
+            }else{
+                if( $tmp !~ /^\-/ and ($prevarg !~ /^\-/i or is_singlearg($prevarg)) ){
+                    push @tmpargv, '--';
+                    $doubledash = 'yes';
+                }
+                push @tmpargv, $tmp;
+                $prevarg = $tmp;
             }
+        }else{
             push @tmpargv, $tmp;
-            $prevarg = $tmp;
         }
     }
 


### PR DESCRIPTION
the slurm2flux argument parsing inserts a space after the first character of arguments that start with a single dash in order to make them work with perl's GetOptions. This update ensures that it will stop inserting spaces once it gets to the users command to avoid messing up any command arguments that start with a single dash.