### PR TITLE
use lowercase #flux: directives in slurm2flux

### DIFF
--- a/src/slurm2flux.pl
+++ b/src/slurm2flux.pl
@@ -386,7 +386,7 @@ sub printFluxScript
     print $outshebang;
     print "### Flux directives ###\n";
     foreach my $fluxopt (@OPTIONS){
-        print "#FLUX: $fluxopt\n";
+        print "#flux: $fluxopt\n";
     }
     print "\n";
     print "### Original script. ###\n";


### PR DESCRIPTION
per Jim's preference for not shouting.